### PR TITLE
(misc) dont explicitly install ruby-ffi

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ On Archlinux machines the following Hiera data will install the dependencies usi
 mcollective_agent_process::manage_gem_dependencies: false
 mcollective_agent_process::package_dependencies:
   ruby-sys-proctable: present
-  ruby-ffi: present
 ```
 
 ## Configuration


### PR DESCRIPTION
ruby-ffi is now a dependenc for ruby-sys-proctable, so we don't need to
install it explicitly. See: https://www.archlinux.org/packages/community/any/ruby-sys-proctable/ and https://bugs.archlinux.org/task/58041